### PR TITLE
capture(): wrap io.(p)open calls in an assert

### DIFF
--- a/lib/shell-games.lua
+++ b/lib/shell-games.lua
@@ -177,9 +177,9 @@ local function capture(command)
   local handle
   if NGX_UNSTABLE_POPEN then
     result, err = execute(command)
-    handle = io.open(tmp_output_path, "r")
+    handle = assert(io.open(tmp_output_path, "r"))
   else
-    handle = io.popen(command, "r")
+    handle = assert(io.popen(command, "r"))
   end
   local all_output = handle:read("*a")
 


### PR DESCRIPTION
These operations might fail unnoticed, and then show a very unhelpful
error message about handle being nil at the line below.

By wrapping these calls in an assert, we actually get an error where it
happens, and can see the error message.