### PR TITLE
Fix make test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,6 @@ lint:
 	luacheck .
 
 test: lint
-	luarocks make --local shell-games-git-1.rockspec
 	busted $(BUSTED_ARGS) spec
 
 install-test-deps-apk:

--- a/shell-games.lua
+++ b/shell-games.lua
@@ -1,0 +1,1 @@
+lib/shell-games.lua


### PR DESCRIPTION
For unknown reason make test runs luarocks.

This fails with:
Error: The --local flag is meant for operating in a user's home directory. You are running as a superuser, which is intended for system-wide operation. To force using the superuser's home, use --tree explicitly. Makefile:16: recipe for target 'test' failed

Further lurarocks is useless for making the module available for testing, anyway:
luarocks --tree /root/.luarocks make shell-games-git-1.rockspec

shell-games git-1 is now installed in /root/.luarocks (license: MIT)

busted  spec
✱✱✱◼foo
◼●●◼✱✱✱✱
2 successes / 3 failures / 7 errors / 0 pending : 0.006871 seconds ...
Error → spec/capture_spec.lua @ 1
capture
Random seed: 818637692
spec/capture_spec.lua:2: module 'shell-games' not found: